### PR TITLE
move definitions from tc.h into tc_externs.c, declare as extern in tc.h

### DIFF
--- a/makefile
+++ b/makefile
@@ -34,7 +34,7 @@ INSTALLTC = /usr/local/bin/tinyc
 INSTALLLIB = /usr/local/share/tinyC/library.tc
 LATEST = ls -lt $(TC) $(INSTALLTC) $(LIB) $(INSTALLLIB)
 
-OBJMOST = tc.o FileRead.o debug.o machineCall.o platform.o var.o stack.o dialog.o
+OBJMOST = tc_externs.o tc.o FileRead.o debug.o machineCall.o platform.o var.o stack.o dialog.o
 
 OBJALL = $(OBJMOST) tcTestMain.o tcMain.o test.o
 
@@ -45,7 +45,7 @@ OBJTC = $(OBJMOST) tcMain.o
 OBJTEST = $(OBJMOST) test.o tcTestMain.o
 
 # All the header and c files
-SRCS = test.c tc.c machineCall.c var.c stack.c tcTestMain.c tcMain.c \
+SRCS = tc_externs.c test.c tc.c machineCall.c var.c stack.c tcTestMain.c tcMain.c \
 platform.c dialog.c
 HDRS = tc.h
 
@@ -54,7 +54,8 @@ HDRS = tc.h
 -Wno-unused-variable -Wno-unused-but-set-variable
 #CLIBS = -L/usr/lib/x86_64-linux-gnu -ldl -lm
 CLIBS =  -ldl -lm
-CFLAGS = -w -g -m32
+CFLAGS = -w -g -m32 
+#-fcommon
 #CFLAGS = 
 .PHONY: all run difft diffd keep dotest install latest
 all: $(TC) $(TEST)

--- a/tc.h
+++ b/tc.h
@@ -1,3 +1,6 @@
+#ifndef TC_H_INCLUDED
+#define TC_H_INCLUDED
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
@@ -26,9 +29,9 @@
 #define VS 2
 #define VP 3
 #define VV 4
-char verbose[8];
-int debug;
-int quiet;
+extern char verbose[8];
+extern int debug;
+extern int quiet;
 
 /* error tags */
 #define STATERR      1
@@ -73,8 +76,8 @@ struct stackentry {
 	union stuff value; 
 };
 /* the stack */
-struct stackentry *stack;
-int nxtstack, stacklen;
+extern struct stackentry *stack;
+extern int nxtstack, stacklen;
 
 /* a fun entry */
 struct funentry { 
@@ -82,24 +85,24 @@ struct funentry {
 	char* prused;
 };
 /* fun table */
-struct funentry *fun;
-struct funentry *curglbl, *curfun, *efun;
+extern struct funentry *fun;
+extern struct funentry *curglbl, *curfun, *efun;
 
 struct var { 
 	char name[VLEN+1]; int class; Type type; int len; int brkpt;
 	union stuff value; 
 };
 /* variable table */
-struct var *vartab;
-int nxtvar, vtablen;
+extern struct var *vartab;
+extern int nxtvar, vtablen;
 
 /* most recent function entered */
-char fcnName[VLEN+1];
+extern char fcnName[VLEN+1];
 void saveName();
 
 /* program space */
-char* pr;
-char *lpr, *apr, *endapp, *prused, *EPR;
+extern char* pr;
+extern char *lpr, *apr, *endapp, *prused, *EPR;
 
 /* EPR is end of program SPACE. 
  *	pr starts with startSeed, then libs, then app, then values
@@ -112,17 +115,17 @@ char *lpr, *apr, *endapp, *prused, *EPR;
  */
 
 /************ Globals **************/
-int error, leave, brake;
-char* fname;
-char* lname;
-char* cursor;
-char* stcurs;
-char* errat;
-int obsize, vclass, alen;
-int traceMode;
+extern int error, leave, brake;
+extern char* fname;
+extern char* lname;
+extern char* cursor;
+extern char* stcurs;
+extern char* errat;
+extern int obsize, vclass, alen;
+extern int traceMode;
 extern char* ppsPath;
 
-FILE* fileUnit[MAX_UNIT];
+extern FILE* fileUnit[MAX_UNIT];
 int tcFopen(char* name, char* mode);
 int tcFputs(char* str, int unit);
 int tcFputc(char c, int unit);
@@ -216,3 +219,4 @@ int _symName();
 int charIn(char c, char *choices );
 void pFmt(char *fmt, INT *args);
 int _skip(char l, char r);
+#endif

--- a/tcMain.c
+++ b/tcMain.c
@@ -13,7 +13,7 @@ extern int  (*piMC )(int,int,int*);
 int naf(int nargs, int *args);
 
 char* startSeed="[main();]";
-char* ppsPath="./pps";
+//char* ppsPath="./pps";
 
 void tcUsage() {
 	printf("Usage: tc [-q] [-d] [-r seed-code] appfile");

--- a/tc_externs.c
+++ b/tc_externs.c
@@ -1,0 +1,23 @@
+#include "tc.h"
+char verbose[8];
+int debug;
+int quiet;
+struct stackentry *stack;
+int nxtstack, stacklen;
+struct funentry *fun;
+struct funentry *curglbl, *curfun, *efun;
+struct var *vartab;
+int nxtvar, vtablen;
+char fcnName[VLEN+1];
+char* pr;
+char *lpr, *apr, *endapp, *prused, *EPR;
+int error, leave, brake;
+char* fname;
+char* lname;
+char* cursor;
+char* stcurs;
+char* errat;
+int obsize, vclass, alen;
+int traceMode;
+char* ppsPath="./pps";
+FILE* fileUnit[MAX_UNIT];


### PR DESCRIPTION
In recent versions of GCC, eg. on Ubuntu 22.04 (GCC 11.4), the compiler flag -fno-common is the default, which means that variables declared in tc.h are compiled into separate linkage units and not merged together. A quick hack is to add the -fcommon switch to the makefile, but I thought it would be good to move these variables to a file of externs, which I called tc_externs.c. They are declared (not defined) as extern within tc.h.

Ref:
https://www.openmx-square.org/forum/patio.cgi?mode=view&no=2904&fbclid=IwAR0YvIjYL8sVtKHniePaUC1VbX4EqiaJ_WRNO8Y500wCOlmnA9t4N45Op2w

https://stackoverflow.com/questions/496448/how-to-correctly-use-the-extern-keyword-in-c?fbclid=IwAR3xbqkYRxeX8V_CVi_tWGC2tHg9lyLC1ALcq1QL43IPsmM7H1F4C_2MR-o

